### PR TITLE
Removed environment specification for older flutter version

### DIFF
--- a/encryption/example/pubspec.yaml
+++ b/encryption/example/pubspec.yaml
@@ -29,8 +29,3 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
-
-environment:
-  sdk: ">=1.19.0 <2.0.0"
-  flutter: "^0.2.8"

--- a/encryption/pubspec.yaml
+++ b/encryption/pubspec.yaml
@@ -8,45 +8,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-environment:
-  sdk: ">=1.19.0 <2.0.0"
-  flutter: "^0.2.8"
-
 # The following section is specific to Flutter.
 flutter:
   plugin:
     androidPackage: com.oneconnect.encryption
     pluginClass: EncryptionPlugin
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages


### PR DESCRIPTION
When using this plugin I realized that I was unable to use the most recent version of the Flutter SDK (3.0) due to this package specifying older versions. This pull request removes this specification allowing more up-to-date versions of the Flutter SDK to be used.